### PR TITLE
Improve return value type hinting on a handful of values

### DIFF
--- a/src/Karla/Action/Rotate.php
+++ b/src/Karla/Action/Rotate.php
@@ -39,7 +39,7 @@ class Rotate implements Action
      * @param integer $degree
      *            Degrees to rotate the image
      *
-     * @return Convert
+     * @return \Karla\Program\Convert
      * @throws \InvalidArgumentException if degree is not an integer value
      */
     public function __construct($degree)

--- a/src/Karla/Karla.php
+++ b/src/Karla/Karla.php
@@ -119,7 +119,7 @@ class Karla
     /**
      * Start a convert operation
      *
-     * @return Convert
+     * @return Program\Convert
      */
     public function convert()
     {
@@ -132,7 +132,7 @@ class Karla
     /**
      * Start a identify operation
      *
-     * @return Identify
+     * @return Program\Identify
      */
     public function identify()
     {
@@ -145,7 +145,7 @@ class Karla
     /**
      * Start a composite operation
      *
-     * @return Composite
+     * @return Program\Composite
      */
     public function composite()
     {


### PR DESCRIPTION
This is really a dev convenience change. IDEs couldn't resolve return types on all of Karla program methods (convert, identify...) due to lack of proper namespacing on the phpdoc `@return` annotations. This in effect fixes code completion on IDEs for Karla.